### PR TITLE
Makefile installation method & update shebangs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+DESTDIR ?= ~/.local/bin/
+
+.PHONY: install
+
+install:
+	install -m 755 fetch_merge_*.sh $(DESTDIR)/.
+	install -m 755 fetch_merge.py $(DESTDIR)/.
+	echo "Installed to $(DESTDIR)"
+	echo "(Note that 'fetch_merge.py' requires the python 'requests' package to be installed.)"
+	echo "You also must have $(DESTDIR) in your PATH."
+
+uninstall:
+	rm -f $(DESTDIR)/fetch_merge_*.sh
+	rm -f $(DESTDIR)/fetch_merge.py
+	echo "Uninstalled from $(DESTDIR)"

--- a/fetch_merge.py
+++ b/fetch_merge.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import subprocess
 import requests

--- a/fetch_merge_gh.sh
+++ b/fetch_merge_gh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if GitHub CLI is installed
 if ! command -v gh &> /dev/null; then

--- a/fetch_merge_git.sh
+++ b/fetch_merge_git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Function to ask for confirmation
 confirm() {


### PR DESCRIPTION
Add a makefile which defaults to installing all three scripts to `~/.local/bin`, but can be put anywhere using `DESTDIR` environment variable.

Also updated the `.sh` script shebang lines to use `/usr/bin/env` in case bash is in a non-standard location.

Added shebang to the `.py` script.